### PR TITLE
Refactor schema.ts to organize imports and add new database tables for tags, scan paths, and scan path ignores Additional DB tables #11

### DIFF
--- a/apps/server/migrations/0002_freezing_hulk.sql
+++ b/apps/server/migrations/0002_freezing_hulk.sql
@@ -1,0 +1,28 @@
+CREATE TYPE "public"."scan_status" AS ENUM('success', 'error', 'skipped');--> statement-breakpoint
+CREATE TABLE "scan_path_ignores" (
+	"scan_path_id" uuid NOT NULL,
+	"pattern" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "scan_paths" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"path_glob" text NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	"last_scanned_at" timestamp with time zone,
+	"next_scan_at" timestamp with time zone,
+	"last_status" "scan_status",
+	"last_error_message" text,
+	"failure_count" integer DEFAULT 0 NOT NULL,
+	"scan_interval" interval NOT NULL,
+	"priority" smallint DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "tags" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"file_id" uuid NOT NULL,
+	"name" text NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "scan_path_ignores" ADD CONSTRAINT "scan_path_ignores_scan_path_id_scan_paths_id_fk" FOREIGN KEY ("scan_path_id") REFERENCES "public"."scan_paths"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tags" ADD CONSTRAINT "tags_file_id_files_id_fk" FOREIGN KEY ("file_id") REFERENCES "public"."files"("id") ON DELETE no action ON UPDATE no action;

--- a/apps/server/migrations/meta/0002_snapshot.json
+++ b/apps/server/migrations/meta/0002_snapshot.json
@@ -1,0 +1,259 @@
+{
+  "id": "883a36d8-1769-43ee-a4c7-bd19accfccfc",
+  "prevId": "6b0f6874-1835-475a-aff7-8a9da82b88ea",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastIndexedAt": {
+          "name": "lastIndexedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_path_ignores": {
+      "name": "scan_path_ignores",
+      "schema": "",
+      "columns": {
+        "scan_path_id": {
+          "name": "scan_path_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scan_path_ignores_scan_path_id_scan_paths_id_fk": {
+          "name": "scan_path_ignores_scan_path_id_scan_paths_id_fk",
+          "tableFrom": "scan_path_ignores",
+          "tableTo": "scan_paths",
+          "columnsFrom": [
+            "scan_path_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_paths": {
+      "name": "scan_paths",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "path_glob": {
+          "name": "path_glob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_scan_at": {
+          "name": "next_scan_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "scan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scan_interval": {
+          "name": "scan_interval",
+          "type": "interval",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_file_id_files_id_fk": {
+          "name": "tags_file_id_files_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.scan_status": {
+      "name": "scan_status",
+      "schema": "public",
+      "values": [
+        "success",
+        "error",
+        "skipped"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/migrations/meta/_journal.json
+++ b/apps/server/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1750500351965,
       "tag": "0001_noisy_vargas",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1750956226839,
+      "tag": "0002_freezing_hulk",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -1,4 +1,13 @@
-import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+  smallint,
+  integer,
+  interval,
+  pgEnum,
+} from 'drizzle-orm/pg-core';
 
 export const files = pgTable('files', {
   id: uuid('id').defaultRandom().primaryKey(),
@@ -12,4 +21,39 @@ export const files = pgTable('files', {
   deletedAt: timestamp('deletedAt', { withTimezone: true }),
 
   lastIndexedAt: timestamp('lastIndexedAt', { withTimezone: true }).notNull(),
+});
+
+export const tags = pgTable('tags', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  fileId: uuid('file_id')
+    .notNull()
+    .references(() => files.id),
+  name: text('name').notNull(),
+});
+
+export const scanStatusEnum = pgEnum('scan_status', [
+  'success',
+  'error',
+  'skipped',
+]);
+
+export const scanPaths = pgTable('scan_paths', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  pathGlob: text('path_glob').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+  lastScannedAt: timestamp('last_scanned_at', { withTimezone: true }),
+  nextScanAt: timestamp('next_scan_at', { withTimezone: true }),
+  lastStatus: scanStatusEnum('last_status'),
+  lastErrorMessage: text('last_error_message'),
+  failureCount: integer('failure_count').default(0).notNull(),
+  scanInterval: interval('scan_interval').notNull(),
+  priority: smallint('priority').default(0).notNull(),
+});
+
+export const scanPathIgnores = pgTable('scan_path_ignores', {
+  scanPathId: uuid('scan_path_id')
+    .notNull()
+    .references(() => scanPaths.id),
+  pattern: text('pattern').notNull(),
 });


### PR DESCRIPTION
#11